### PR TITLE
Fix metalink generator

### DIFF
--- a/mirrors.list
+++ b/mirrors.list
@@ -1,0 +1,5 @@
+https://yum.qubes-os.org/
+https://mirrors.edge.kernel.org/qubes/repo/yum
+https://ftp.acc.umu.se/mirror/qubes-os.org/repo/yum
+https://ftp.halifax.rwth-aachen.de/qubes/repo/yum
+https://mirrors.dotsrc.org/qubes/repo/yum

--- a/mirrors.list
+++ b/mirrors.list
@@ -3,3 +3,10 @@ https://mirrors.edge.kernel.org/qubes/repo/yum
 https://ftp.acc.umu.se/mirror/qubes-os.org/repo/yum
 https://ftp.halifax.rwth-aachen.de/qubes/repo/yum
 https://mirrors.dotsrc.org/qubes/repo/yum
+https://mirror.hackingand.coffee/qubes/repo/yum
+
+# disabling .onion by default
+#http://ftp.qubesos4rrrrz6n4.onion/repo/yum
+
+# this one does not resolve for me:
+#https://mirrors.ukfast.co.uk/sistes/qubes-os.org/repo/yum

--- a/mirrors.list
+++ b/mirrors.list
@@ -4,9 +4,7 @@ https://ftp.acc.umu.se/mirror/qubes-os.org/repo/yum
 https://ftp.halifax.rwth-aachen.de/qubes/repo/yum
 https://mirrors.dotsrc.org/qubes/repo/yum
 https://mirror.hackingand.coffee/qubes/repo/yum
+https://mirrors.ukfast.co.uk/sites/qubes-os.org/repo/yum
 
 # disabling .onion by default
 #http://ftp.qubesos4rrrrz6n4.onion/repo/yum
-
-# this one does not resolve for me:
-#https://mirrors.ukfast.co.uk/sistes/qubes-os.org/repo/yum

--- a/mkmetalink.py
+++ b/mkmetalink.py
@@ -148,7 +148,6 @@ class RepoMD:
         Mirrors which apparently do not mirror this repo are silently dropped.
         '''
         for mirror in mirrors:
-            sys.stderr.write('mirror={!r}\n'.format(mirror))
             try:
                 relpath = self.path.relative_to(base / mirror.subdir)
             except ValueError:

--- a/mkmetalink.py
+++ b/mkmetalink.py
@@ -98,7 +98,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument('--metalink', '-3',
     action='store_const',
-    dest='format',
+    dest='template',
     const=METALINK3,
     help=argparse.SUPPRESS)
 

--- a/mkmetalink.py
+++ b/mkmetalink.py
@@ -181,7 +181,7 @@ def read_mirrors(path):
             yield Mirror(*line.split())
 
 def main(args=None):
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     repomd = RepoMD(args.repomd)
     urls = list(
         repomd.get_urls_for_mirrors(args.base, read_mirrors(args.mirrors)))


### PR DESCRIPTION
Tested against fedora 25 and 26. Mirrors are from my e-mail archive searched against "mirror" in `Subject:`. Currently not part of repo pipeline, I'd have to figure out how to plug it.

Usage:
```sh
./mkmetalink.py mirrors.list r4.0/current/vm/fc26/repodata/repomd.xml \
    > r4.0/current/vm/fc26/repodata/repomd.xml.metalink
```

This script also supports partial mirrors. Just write subpath to `mirrors.list` after whitespace:
```
https://r40-current.mirror.example/ r4.0/current
```
This is intended for a possibility of optimising out some subparts of the new mirror. We might want to test it before phasing out focaccia with some subset of repos and smaller disk.

QubesOS/qubes-issues#1254